### PR TITLE
Added option to save a DataFrame without Index/header

### DIFF
--- a/dflib-csv/src/main/java/com/nhl/dflib/csv/CsvSaver.java
+++ b/dflib-csv/src/main/java/com/nhl/dflib/csv/CsvSaver.java
@@ -15,9 +15,11 @@ public class CsvSaver {
 
     private CSVFormat format;
     private boolean createMissingDirs;
+    private boolean printHeader;
 
     public CsvSaver() {
         this.format = CSVFormat.DEFAULT;
+        this.printHeader = true;
     }
 
     /**
@@ -41,6 +43,18 @@ public class CsvSaver {
      */
     public CsvSaver createMissingDirs() {
         this.createMissingDirs = true;
+        return this;
+    }
+
+    /**
+     * Instructs the saver to omit saving the Index of a DataFrame.
+     * By default the Index will be saved as a first row in a file.
+     *
+     * @return this saver instance
+     * @since 0.8
+     */
+    public CsvSaver withoutHeader() {
+        this.printHeader = false;
         return this;
     }
 
@@ -68,7 +82,9 @@ public class CsvSaver {
 
         try {
             CSVPrinter printer = new CSVPrinter(out, format);
-            printHeader(printer, df.getColumnsIndex());
+            if (printHeader) {
+                printHeader(printer, df.getColumnsIndex());
+            }
 
             int len = df.width();
             for (RowProxy r : df) {

--- a/dflib-csv/src/test/java/com/nhl/dflib/csv/CsvSaverTest.java
+++ b/dflib-csv/src/test/java/com/nhl/dflib/csv/CsvSaverTest.java
@@ -111,4 +111,16 @@ public class CsvSaverTest extends BaseCsvTest {
 
         Csv.saver().save(df, file);
     }
+
+
+    @Test
+    public void testSave_withoutHeader() {
+        DataFrame df = DataFrame.newFrame("A", "B").foldByRow(
+                1, 2,
+                3, 4);
+
+        assertEquals(
+                "1,2\r\n" +
+                        "3,4\r\n", Csv.saver().withoutHeader().saveToString(df));
+    }
 }


### PR DESCRIPTION
Currently, there is no option to save a DataFrame to CSV without saving an index as a first row, so I've added a configurable option. 