### PR TITLE
Use Exp.getColumnName instead of Exp.toQL

### DIFF
--- a/dflib/src/main/java/com/nhl/dflib/ColumnDataFrame.java
+++ b/dflib/src/main/java/com/nhl/dflib/ColumnDataFrame.java
@@ -549,9 +549,9 @@ public class ColumnDataFrame implements DataFrame {
     public DataFrame selectColumns(Exp<?> exp0, Exp<?>... otherExps) {
         int w = otherExps.length + 1;
         String[] labels = new String[w];
-        labels[0] = exp0.toQL(this);
+        labels[0] = exp0.getColumnName(this);
         for (int i = 1; i < w; i++) {
-            labels[i] = otherExps[i - 1].toQL(this);
+            labels[i] = otherExps[i - 1].getColumnName(this);
         }
 
         Series[] data = new Series[w];

--- a/dflib/src/test/java/com/nhl/dflib/DataFrame_SelectColumnsTest.java
+++ b/dflib/src/test/java/com/nhl/dflib/DataFrame_SelectColumnsTest.java
@@ -74,4 +74,17 @@ public class DataFrame_SelectColumnsTest {
                 .expectRow(0, "x", 1)
                 .expectRow(1, "y", 2);
     }
+
+    @Test
+    public void testWithAsExp(){
+        DataFrame df = DataFrame.newFrame("a", "b").foldByRow(
+                1, "x",
+                2, "y")
+                .selectColumns($col("b"), $int("a").mul($int("a")).as("c"));
+
+        new DataFrameAsserts(df, "b", "c")
+                .expectHeight(2)
+                .expectRow(0, "x", 1)
+                .expectRow(1, "y", 4);
+    }
 }


### PR DESCRIPTION
If I pass AsExp as parameter of DataFrame.selectionColumns , I hope  the column label should be the name   that I passed in AsExp

